### PR TITLE
made TCOD::Color class to work with yaml serialization

### DIFF
--- a/lib/libtcod/bindings.rb
+++ b/lib/libtcod/bindings.rb
@@ -56,6 +56,18 @@ module TCOD
     def to_s
       "<Color #{self[:r]}, #{self[:g]}, #{self[:b]}>"
     end
+
+    def encode_with coder
+      coder['r'] = self[:r]
+      coder['g'] = self[:g]
+      coder['b'] = self[:b]
+    end
+    
+    def init_with coder
+      self[:r] = coder['r']
+      self[:g] = coder['g']
+      self[:b] = coder['b']
+    end
   end
 
   tcod_function :TCOD_color_RGB, [ :uchar, :uchar, :uchar ], Color.val


### PR DESCRIPTION
When working with yaml, `Color` class was not getting serialized properly, leading to nasty interpreter crash when using dumped and loaded `Color`. I'm not sure if my aproach to fixing this problem was right though, I leave it for you to judge.
